### PR TITLE
Add manual QC wait state to mock workflow

### DIFF
--- a/blue_sky/strategies/mock_q_c.py
+++ b/blue_sky/strategies/mock_q_c.py
@@ -31,10 +31,18 @@ class MockQC(MockExecutionStrategy):
 
         return inp 
 
+    def is_even(self, observation_object):
+        return (observation_object.arg1 % 2 == 0)
+
     def set_output_state(self, observation_object):
-        if can_proceed(observation_object.pass_qc):
+        if self.is_even(observation_object):
+            observation_object.fail_qc()
+            observation_object.save()
+
+        elif can_proceed(observation_object.pass_qc):
             observation_object.pass_qc()
             observation_object.save()
+
         else:
             if (observation_object.object_state ==
                 observation_object.__class__.STATE.OBSERVATION_QC_PASSED):
@@ -46,5 +54,4 @@ class MockQC(MockExecutionStrategy):
 
 
     def on_finishing(self, observation_object, results, task):
-        #self.check_key(results, 'arg2')
         self.set_output_state(observation_object)

--- a/blue_sky/strategies/mock_wait.py
+++ b/blue_sky/strategies/mock_wait.py
@@ -8,7 +8,7 @@ class MockWait(WaitStrategy):
         # Use this to check if the reference set is available
         # return true if the state is correc
 
-        if Observation.STATE.OBSERVATION_DONE != obs.object_state:
+        if Observation.STATE.OBSERVATION_QC_PASSED != obs.object_state:
             return True
 
         return False

--- a/config/workflow_config.yml
+++ b/config/workflow_config.yml
@@ -43,6 +43,13 @@ workflows:
               executable: "mock"
               batch_size: 100
 
+            - key: "mock_wait"
+              label: "Mock Wait"
+              class: "blue_sky.strategies.mock_wait.MockWait"
+              enqueued_class: "blue_sky.models.observation.Observation"
+              executable: "mock"
+              batch_size: 100
+
             - key: "mock_calibrate"
               label: "Mock Calibrate"
               class: "blue_sky.strategies.mock_calibrate.MockCalibrate"
@@ -76,6 +83,7 @@ workflows:
             - [ "mock_preprocess", [ "mock_analyze" ] ]
             - [ "mock_calibrate", [ "mock_analyze" ] ]
             - [ "mock_analyze", [ "mock_qc" ] ]
-            - [ "mock_qc", [ "group_assign" ] ]
+            - [ "mock_qc", [ "mock_wait" ] ]
+            - [ "mock_wait", [ "group_assign" ] ]
             - [ "group_assign", [ "process_grouped" ] ]
             - [ "process_grouped", [ "complete_group" ] ]

--- a/example/example_ingest.py
+++ b/example/example_ingest.py
@@ -1,0 +1,28 @@
+from workflow_engine.ingest.ingest_client import IngestClient
+
+client = IngestClient('blue_sky__blue', 'mock_workflow')
+client.configure_celery_app()
+
+calibration_ids = dict()
+
+for offset in range(2):
+    response = client.send({ 'offset': (offset - 100 * 0.001) }, fix_option=['calibration'])
+    calibration_ids[offset] = response['calibration_id']
+
+for measurement in range(20):
+    calibration_index = int(measurement / 10)
+    print(calibration_index)
+    calibration_id = calibration_ids[calibration_index]
+
+    client.send(
+        {
+            'arg1': measurement,
+            'arg2': 'something',
+            'arg3': 'whatever',
+            'calibration_id': calibration_id
+        },
+        fix_option=['observation']
+    )
+
+
+


### PR DESCRIPTION
- Add a wait workflow node that holds QC failed jobs for manual QC after mock QC 
- The mock QC now fails every other observation to give something to QC
- Add an example ingest script that ingests 20 observations and 2 corresponding calibration objects. When run through the whole workflow this results in two complete groups.
- Add an admin action for observations that sets the state to QC passed and triggers the workflow to continue processing.
