### PR TITLE
better parameters for adjusting example workload

### DIFF
--- a/blue_sky/models/observation_group.py
+++ b/blue_sky/models/observation_group.py
@@ -9,6 +9,8 @@ class ObservationGroup(Enqueueable, Stateful, models.Model):
         :height: 300px
     '''
 
+    GROUP_SIZE = 2
+
     class STATE:
         GROUP_INCOMPLETE = "INCOMPLETE"
         GROUP_COMPLETE = "COMPLETE"

--- a/blue_sky/strategies/mock_complete_group.py
+++ b/blue_sky/strategies/mock_complete_group.py
@@ -1,5 +1,5 @@
 from .mock_execution_strategy import MockExecutionStrategy
-from blue_sky.models import Observation
+from blue_sky.models import Observation, ObservationGroup
 import logging
 import copy
 
@@ -18,7 +18,7 @@ class MockCompleteGroup(MockExecutionStrategy):
                 object_state=Observation.STATE.OBSERVATION_DONE
             )
 
-            if observations.count() == 10:
+            if observations.count() == ObservationGroup.GROUP_SIZE:
                 objects = objects | { grp }
 
         return list(objects)

--- a/blue_sky/strategies/mock_group_assignment.py
+++ b/blue_sky/strategies/mock_group_assignment.py
@@ -12,9 +12,9 @@ class MockGroupAssignment(MockExecutionStrategy):
     _base_input_dict = {}
 
     def transform_objects_for_queue(self, observation):
-        tens = int(observation.arg1) // 10
+        group_index = int(observation.arg1) // ObservationGroup.GROUP_SIZE
 
-        group_label = 'Group {}'.format(tens)
+        group_label = 'Group {}'.format(group_index)
 
         group, _ = ObservationGroup.objects.get_or_create(
             label=group_label,

--- a/blue_sky/strategies/mock_process_grouped_observations.py
+++ b/blue_sky/strategies/mock_process_grouped_observations.py
@@ -1,5 +1,5 @@
 from .mock_execution_strategy import MockExecutionStrategy
-from blue_sky.models import Observation
+from blue_sky.models import Observation, ObservationGroup
 from django_fsm import can_proceed
 import logging
 import copy
@@ -18,7 +18,7 @@ class MockProcessGroupedObservations(MockExecutionStrategy):
             observations = grp.observations.filter(
                 object_state=Observation.STATE.OBSERVATION_GROUPED)
 
-            if observations.count() == 10:
+            if observations.count() == ObservationGroup.GROUP_SIZE:
                 objects = objects | set(observations)
 
         return list(objects) 

--- a/example/example_ingest.py
+++ b/example/example_ingest.py
@@ -3,14 +3,20 @@ from workflow_engine.ingest.ingest_client import IngestClient
 client = IngestClient('blue_sky__blue', 'mock_workflow')
 client.configure_celery_app()
 
+GROUP_COUNT = 5
+GROUP_SIZE = 2
+OBSERVATION_COUNT=GROUP_SIZE*GROUP_COUNT
+OBSERVATIONS_PER_CALIBRATION=2
+CALIBRATION_COUNT=int(OBSERVATION_COUNT/OBSERVATIONS_PER_CALIBRATION)
+
 calibration_ids = dict()
 
-for offset in range(2):
+for offset in range(CALIBRATION_COUNT):
     response = client.send({ 'offset': (offset - 100 * 0.001) }, fix_option=['calibration'])
     calibration_ids[offset] = response['calibration_id']
 
-for measurement in range(20):
-    calibration_index = int(measurement / 10)
+for measurement in range(OBSERVATION_COUNT):
+    calibration_index = int(measurement / GROUP_SIZE)
     print(calibration_index)
     calibration_id = calibration_ids[calibration_index]
 
@@ -23,6 +29,3 @@ for measurement in range(20):
         },
         fix_option=['observation']
     )
-
-
-


### PR DESCRIPTION
This change parametrizes a few things in the example workflow so I can have more or fewer jobs and messages happen at various parts of the workflow. I'm using it to reproduce and debug messaging issues and to develop the slurm worker.

There are also accompanying changes in the workflow engine that add slightly more realistic delays between the mock pbs_id, running and finished messages from the mock worker.

It still requires a code change to adjust, which isn't ideal, but I'm trying to keep the changes small.