### PR TITLE
DT-1253 slurm worker

### DIFF
--- a/blue_sky/test_settings.py
+++ b/blue_sky/test_settings.py
@@ -33,6 +33,10 @@ ADMIN_URL='http://' + UI_HOST + ':' + str(9002) + '/admin'
 NOTEBOOK_URL='http://' + UI_HOST + ':' + str(UI_PORT) + '/nb/'
 JOB_GRID_CLASS=None
 
+SLURM_ENDPOINT = 'http://slurm.corp.alleninstitute.org/api/slurm/v0.0.36'
+SLURM_AUTH = 'TeStUsEr:TeStToKeN'
+SLURM_TIMEOUT = 180
+
 MOAB_ENDPOINT = 'http://qmaster2.corp.alleninstitute.org:8080/mws/rest'
 MOAB_AUTH = 'user:pass'
 MOAB_GROUP = 'lab_b'

--- a/tests/strategies/test_execution.py
+++ b/tests/strategies/test_execution.py
@@ -118,7 +118,7 @@ def test_finish_task(
             mock_open(read_data='{ "data": "whatever" }')):
             ex_strat.finish_task(task_with_storage_directory)
 
-    mock_chmod.assert_called()
+    mock_chmod.assert_not_called()
     mock_isfile.assert_has_calls([
         call('/path/to/storage/mock_enqueued_object'
         '/10/jobs/job_789/tasks/task_123456/output_123456.json')
@@ -214,13 +214,15 @@ def test_get_input_file(
     ex_strat,
     task_with_storage_directory):
 
-    infile = ex_strat.get_input_file(task_with_storage_directory)
+
+    with patch('os.path.exists', Mock(return_value=True)):
+        infile = ex_strat.get_input_file(task_with_storage_directory)
 
     assert infile == (
         '/path/to/storage/mock_enqueued_object'
         '/10/jobs/job_789/tasks/task_123456/input_123456.json'
     )
-    mock_chmod.assert_called()
+    mock_chmod.assert_not_called()
 
 @patch('os.chmod')
 def test_get_pbs_file(
@@ -228,13 +230,14 @@ def test_get_pbs_file(
     ex_strat,
     task_with_storage_directory):
 
-    pbs_file = ex_strat.get_pbs_file(task_with_storage_directory)
+    with patch('os.path.exists', Mock(return_value=True)):
+        pbs_file = ex_strat.get_pbs_file(task_with_storage_directory)
 
     assert pbs_file == (
         '/path/to/storage/mock_enqueued_object'
         '/10/jobs/job_789/tasks/task_123456/pbs_123456.pbs'
     )
-    mock_chmod.assert_called()
+    mock_chmod.assert_not_called()
 
 
 @patch('os.chmod')

--- a/tests/workers/test_pbs_utils.py
+++ b/tests/workers/test_pbs_utils.py
@@ -1,0 +1,55 @@
+import pytest
+from mock import Mock, patch
+from workflow_engine.pbs_utils import PbsUtils
+
+def test_slurm_script():
+    script_generator = PbsUtils()
+
+    mock_executable = Mock()
+   
+    mock_executable.remote_queue = 'slurm'
+    mock_executable.pbs_queue = 'MoCkQuEuENaMe'
+    mock_executable.pbs_processor = '--mem=256:--ntasks=20'
+    mock_executable.pbs_walltime = 'walltime=1:23:45'
+    mock_task = Mock() 
+    mock_task.id = 12345
+    mock_task.get_task_name = Mock(return_value='task_12345')
+    mock_task.log_file = '/path/to/mock.log'
+    mock_task.full_executable = '/path/to/full/executable --arg1 value1'
+    mock_task.environment_vars = Mock(return_value=['A=B', 'C=D'])
+    mock_settings = Mock()
+    mock_settings.PBS_CONDA_ENV = 'MoCk_EnViRoNmEnT'
+    mock_settings.PBS_RESPONSE_CONDA_ENV = 'MoCk_ReSpOnSe_EnViRoNmEnT'
+    mock_settings.HPC_RESPONSE_PYTHONPATH = 'HpC_ReSpOnSe_PyThOnPaTh'
+    mock_settings.BLUE_SKY_SETTINGS_HPC_RESPONSE = 'BlUe_sKy_SeTtInGs_HpC_rEsPoNsE'
+    mock_settings.APP_PACKAGE = 'BlUe_SkY'
+
+    slurm_template = script_generator.get_template(
+        mock_executable,
+        mock_task,
+        mock_settings
+    )
+
+    assert script_generator is not None
+
+    for line in [
+        '#SBATCH -p MoCkQuEuENaMe',
+        '#SBATCH --mem=256',
+        '#SBATCH --ntasks=20',
+        '#SBATCH --time 1:23:45',
+        '#SBATCH --job-name task_12345',
+        '#SBATCH -o /path/to/mock.log',
+        'source activate MoCk_ReSpOnSe_EnViRoNmEnT',
+        'python -m workflow_engine.mini_response --action finished 12345 --app-name BlUe_SkY',
+        'export TMPDIR="/scratch/capacity/${SLURM_JOBID}/"',
+        'export SPARK_LOCAL_DIRS="/scratch/capacity/${SLURM_JOBID}/"',
+        'export BLUE_SKY_SETTINGS=BlUe_sKy_SeTtInGs_HpC_rEsPoNsE',
+        'export A=B',
+        'export C=D',
+        'export PYTHONPATH=${PYTHONPATH}:HpC_ReSpOnSe_PyThOnPaTh', 
+        'source activate MoCk_ReSpOnSe_EnViRoNmEnT',
+        'python -m workflow_engine.mini_response --action running 12345 --app-name BlUe_SkY',
+        'source activate MoCk_EnViRoNmEnT',
+        '/path/to/full/executable --arg1 value1'
+    ]:
+        assert line in slurm_template

--- a/tests/workers/test_slurm_api.py
+++ b/tests/workers/test_slurm_api.py
@@ -1,0 +1,90 @@
+import pytest
+from mock import Mock, patch
+from workflow_engine.process.workers.slurm_api import SlurmApi
+from urllib3 import PoolManager
+import json
+
+
+def test_slurm_api_jobs_url():
+    slurm = SlurmApi()
+    url = slurm.slurm_url(table='jobs')
+
+    assert url == 'http://slurm.corp.alleninstitute.org/api/slurm/v0.0.36/jobs'
+
+def test_slurm_api_job_id_url():
+    slurm = SlurmApi()
+
+    url = slurm.slurm_url(table='job', oid='submit')
+
+    assert url == 'http://slurm.corp.alleninstitute.org/api/slurm/v0.0.36/job/submit'
+
+def test_slurm_headers():
+    slurm = SlurmApi()
+    headers = slurm.slurm_headers()
+
+    assert headers['Content-Type'] == 'application/json'
+    assert headers['X-SLURM-USER-NAME'] == 'TeStUsEr'
+    assert headers['X-SLURM-USER-TOKEN'] == 'TeStToKeN'
+
+def test_slurm_job_submit_payload():
+    slurm = SlurmApi()
+    payload = slurm.submit_job_payload(
+        1234,
+        '/path/to/test/script',
+        "#!/usr/bin/env bash\nsleep 160"
+    )
+
+    assert 'job' in payload
+    assert payload['job']['account'] == 'TeStUsEr'
+    assert payload['job']['ntasks'] == 1
+    assert payload['job']['cpus_per_task'] == 1
+    assert payload['job']['name'] == 'task_1234'
+    assert payload['job']['current_working_directory'] == '/path/to/test/script'
+    assert payload['job']['time_limit'] == 600
+
+    assert 'PATH' in payload['job']['environment']
+    assert 'script' in payload
+
+@pytest.mark.parametrize("status,expected", [(200,True), (500,False)])
+def test_slurm_delete_job(status, expected):
+    slurm = SlurmApi()
+
+    mock_response = Mock()
+    mock_response.status = status
+    mock_request = Mock(return_value=mock_response)
+
+    with patch.object(PoolManager, 'request', mock_request) as mr:
+        result = slurm.delete_slurm_task(9876)
+
+    assert result == expected
+
+    mr.assert_called_with(
+        'DELETE',
+        'http://slurm.corp.alleninstitute.org/api/slurm/v0.0.36/job/9876',
+        headers={'Content-Type': 'application/json', 'X-SLURM-USER-NAME': 'TeStUsEr', 'X-SLURM-USER-TOKEN': 'TeStToKeN'}
+    )
+    
+
+
+def test_slurm_submit_job():
+    slurm = SlurmApi()
+
+    mock_response = Mock()
+    mock_response.status = 200
+    mock_response.data = json.dumps({ 'job_id': 9876 })
+    mock_request = Mock(return_value=mock_response)
+
+    with patch.object(PoolManager, 'request', mock_request) as mr:
+        slurm_id = slurm.submit_job(
+             1234,
+             '/path/to/test/script',
+             "#!/usr/bin/env bash\nsleep 160"
+        )
+
+        assert slurm_id == 9876
+
+        mr.assert_called_with( 
+            'POST',
+            'http://slurm.corp.alleninstitute.org/api/slurm/v0.0.36/job/submit',
+            headers={'Content-Type': 'application/json', 'X-SLURM-USER-NAME': 'TeStUsEr', 'X-SLURM-USER-TOKEN': 'TeStToKeN'},
+            body=b'{"job": {"account": "TeStUsEr", "ntasks": 1, "cpus_per_task": 1, "name": "task_1234", "current_working_directory": "/path/to/test/script", "time_limit": 600, "environment": {"PATH": "/bin:/usr/bin:/usr/local/bin"}}, "script": "#!/usr/bin/env bash\\nsleep 160"}')


### PR DESCRIPTION
Updated tests for slurm worker code.
I'm mostly just slotting in slurmrestd requests for job submit and job delete in place of the moab requests.
Actual code will be in a separate PR in the workflow engine repo

Next steps are to deploy to an em-131db environment (either full deploy or patch) and run some test jobs